### PR TITLE
Issue#49

### DIFF
--- a/budget-app/src/Navbar.jsx
+++ b/budget-app/src/Navbar.jsx
@@ -29,7 +29,7 @@ function Navbar() {
 	});
 
   return (
-    <div>
+    <React.Fragment>
       <AppBar position="static">
         <Toolbar variant="dense">
           <Stack direction="row" spacing={3}>
@@ -57,7 +57,7 @@ function Navbar() {
         open={openCreateModal}
         close={handleClose}
       />
-    </div>
+    </React.Fragment>
   )
 };
 

--- a/budget-app/src/pages/EditModalButton.jsx
+++ b/budget-app/src/pages/EditModalButton.jsx
@@ -35,7 +35,7 @@ function EditModalButton(props) {
 	});
 
     return (
-        <div>
+        <React.Fragment>
             <IconButton
                 aria-label="edit"
                 size="small"
@@ -51,7 +51,7 @@ function EditModalButton(props) {
                 open={openModal}
                 close={handleModalClose}
             />
-        </div>
+        </React.Fragment>
     );
 };
 

--- a/budget-app/src/pages/FormLoader.jsx
+++ b/budget-app/src/pages/FormLoader.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import CreateForm from './CreateForm'
+import EditForm from './EditForm';
+
+function FormLoader(props) {
+    if (props.create) {
+        return (
+            <CreateForm 
+                close={props.close}
+            />
+        );
+    }
+    if (props.edit) {
+        return (
+            <EditForm
+                record={props.record}
+                onClose={props.close}
+            />
+        );
+    }
+}
+
+export default FormLoader;

--- a/budget-app/src/pages/FormLoader.jsx
+++ b/budget-app/src/pages/FormLoader.jsx
@@ -5,19 +5,10 @@ import EditForm from './EditForm';
 
 function FormLoader(props) {
     if (props.create) {
-        return (
-            <CreateForm 
-                close={props.close}
-            />
-        );
+        return (<CreateForm close={props.close} />);
     }
     if (props.edit) {
-        return (
-            <EditForm
-                record={props.record}
-                onClose={props.close}
-            />
-        );
+        return (<EditForm record={props.record} onClose={props.close} />);
     }
 }
 

--- a/budget-app/src/pages/GenericModal.jsx
+++ b/budget-app/src/pages/GenericModal.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 
 import Box from '@mui/material/Box';
-import CreateForm from './CreateForm'
-import EditForm from './EditForm';
+import FormLoader from './FormLoader';
 import Modal from '@mui/material/Modal';
 
 const modalStyles = {
@@ -18,39 +17,23 @@ const modalStyles = {
 };
 
 function GenericModal(props) {
-    if (props.create) {
-        return (
-            <Modal
-                open={props.open}
-                onClose={props.close}
-                aria-labelledby="modal-modal-title"
-                aria-describedby="modal-modal-description"
-            >
-                <Box sx={modalStyles}>
-                    <CreateForm 
-                        close={props.close}
-                    />
-                </Box>
-            </Modal>
-        );
-    }
-    if (props.edit) {
-        return (
-            <Modal
-                open={props.open}
-                onClose={props.close}
-                aria-labelledby="modal-modal-title"
-                aria-describedby="modal-modal-description"
-            >
-                <Box sx={modalStyles}>
-                    <EditForm
-                        record={props.record}
-                        onClose={props.close}
-                    />
-                </Box>
-            </Modal>
-        );
-    }
+    return ( 
+        <Modal 
+            open={props.open}
+            onClose={props.close}
+            aria-labelledby="modal-modal-title"
+            aria-describedby="modal-modal-description"
+        >
+            <Box sx={modalStyles}>
+                <FormLoader
+                    create={props.create}
+                    edit={props.edit}
+                    close={props.close}
+                    record={props.record}
+                />
+            </Box>
+        </Modal> 
+    );
 };
 
 export default GenericModal;

--- a/budget-app/src/pages/Months.jsx
+++ b/budget-app/src/pages/Months.jsx
@@ -35,21 +35,21 @@ function Months() {
 			</TableHead>
 			<TableBody>
 				{months.map((m, index) => (
-				<TableRow
-					key={index}
-					sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
-				>
-					<TableCell component="th" scope="row">{m.Month}</TableCell>
-					<TableCell>{m.Year}</TableCell>
-					<TableCell>${m.Projected}</TableCell>
-					<TableCell>${m.Actual}</TableCell>
-					<TableCell>${m.Savings}</TableCell>
-					<TableCell align="right">
-						<IconButton aria-label="edit" size="small">
-							<ModeEditIcon fontSize="inherit" />
-						</IconButton>
-					</TableCell>
-				</TableRow>
+					<TableRow
+						key={index}
+						sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+					>
+						<TableCell component="th" scope="row">{m.Month}</TableCell>
+						<TableCell>{m.Year}</TableCell>
+						<TableCell>${m.Projected}</TableCell>
+						<TableCell>${m.Actual}</TableCell>
+						<TableCell>${m.Savings}</TableCell>
+						<TableCell align="right">
+							<IconButton aria-label="edit" size="small">
+								<ModeEditIcon fontSize="inherit" />
+							</IconButton>
+						</TableCell>
+					</TableRow>
 				))}
 			</TableBody>
 			</Table>


### PR DESCRIPTION
- React Explained explains that if you want to wrap sibling components in a non-rendering tag, you can use `<React.Fragment> </React.Fragment>` instead of div and the main jsx tag won't even render.
- Also, #49 ---> FormLoader component instead of tons of conditionals in GenericModal. So rather than GenericModal getting really bloated, this routing logic happens in FormLoader component.

