### PR TITLE
Issue#42

### DIFF
--- a/budget-app/src/pages/Transactions.jsx
+++ b/budget-app/src/pages/Transactions.jsx
@@ -18,7 +18,7 @@ function Transactions() {
 		.then(transactions => {
 		  setTransactions(transactions.transactions);
 		});
-	  }, []);
+	}, []);
 
 	return (
 		<TableContainer component={Paper}>

--- a/budget/transactions.py
+++ b/budget/transactions.py
@@ -22,7 +22,7 @@ def get_transactions():
     curs = get_db_cursor(db)
     curs.execute(
         f'SELECT t.Id, t.Location, t.Amount, t.Date, c.Id AS CategoryId, c.Description as Category'
-        f' FROM transactions t INNER JOIN Categories c ON t.CategoryId = c.Id;'
+        f' FROM transactions t INNER JOIN Categories c ON t.CategoryId = c.Id'
         f' ORDER BY t.Date DESC;'
     )
     t = curs.fetchall()


### PR DESCRIPTION
This change was absolutely ridiculous -- it wasn't until I opened my sql tool and queried the data with the query where I noticed the misplaced semi-colon in the query... *facepalm*

Date ordering on transactions is working properly now Issue #42 can be closed with this